### PR TITLE
FIX: Query Error for Post Statuses

### DIFF
--- a/api/src/features/blog/blog.module.ts
+++ b/api/src/features/blog/blog.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { BlogAuthorController } from '@api/features/blog/controllers/blog-author.controller';
 import { BlogPostController } from './controllers/blog-post.controller';
+import { BlogPostStatusController } from './controllers/blog-post-status.controller';
 import { BlogTopicController } from './controllers/blog-topic.controller';
 
 import { BlogAuthor } from './entities/blog-author.entity';
@@ -12,6 +13,7 @@ import { BlogTopic } from './entities/blog-topic.entity';
 
 import { BlogAuthorService } from './services/blog-author.service';
 import { BlogPostService } from './services/blog-post.service';
+import { BlogPostStatusService } from './services/blog-post-status.service';
 import { BlogTopicService } from './services/blog-topic.service';
 
 @Module({
@@ -21,16 +23,19 @@ import { BlogTopicService } from './services/blog-topic.service';
     exports: [
         BlogAuthorService,
         BlogPostService,
+        BlogPostStatusService,
         BlogTopicService
     ],
     controllers: [
         BlogAuthorController,
         BlogPostController,
+        BlogPostStatusController,
         BlogTopicController
     ],
     providers: [
         BlogAuthorService,
         BlogPostService,
+        BlogPostStatusService,
         BlogTopicService
     ]
 })

--- a/api/src/features/blog/blog.module.ts
+++ b/api/src/features/blog/blog.module.ts
@@ -28,8 +28,8 @@ import { BlogTopicService } from './services/blog-topic.service';
     ],
     controllers: [
         BlogAuthorController,
-        BlogPostController,
         BlogPostStatusController,
+        BlogPostController,
         BlogTopicController
     ],
     providers: [

--- a/api/src/features/blog/controllers/blog-post-status.controller.ts
+++ b/api/src/features/blog/controllers/blog-post-status.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, HttpCode, Req, UseGuards } from '@nestjs/common';
+
+import { Request } from 'express';
+
+import { JwtAuthGuard } from '@api/core/auth/jwt/jwt-auth.guard';
+
+import { BlogPostStatus } from '../entities/blog-post-status.entity';
+import { BlogPostStatusService } from '../services/blog-post-status.service';
+import { BlogPostStatusesWereNotFoundException } from '../exceptions/blog-post.exception';
+
+@Controller('blog/posts/statuses')
+export class BlogPostStatusController {
+    constructor(
+        private readonly blogPostStatusService: BlogPostStatusService
+    ) { }
+
+    @Get('')
+    @HttpCode(200)
+    @UseGuards(JwtAuthGuard)
+    async getPostStatuses(@Req() request: Request): Promise<BlogPostStatus[]> {
+        const statuses = await this.blogPostStatusService.getStatuses();
+        if(statuses.length === 0) throw new BlogPostStatusesWereNotFoundException();
+
+        console.log(statuses);
+        return statuses;
+    }
+}

--- a/api/src/features/blog/controllers/blog-post-status.controller.ts
+++ b/api/src/features/blog/controllers/blog-post-status.controller.ts
@@ -6,7 +6,7 @@ import { JwtAuthGuard } from '@api/core/auth/jwt/jwt-auth.guard';
 
 import { BlogPostStatus } from '../entities/blog-post-status.entity';
 import { BlogPostStatusService } from '../services/blog-post-status.service';
-import { BlogPostStatusesWereNotFoundException } from '../exceptions/blog-post.exception';
+import { BlogPostStatusesWereNotFoundException } from '../exceptions/blog-post-status.exception';
 
 @Controller('blog/posts/statuses')
 export class BlogPostStatusController {

--- a/api/src/features/blog/controllers/blog-post-status.controller.ts
+++ b/api/src/features/blog/controllers/blog-post-status.controller.ts
@@ -21,7 +21,6 @@ export class BlogPostStatusController {
         const statuses = await this.blogPostStatusService.getStatuses();
         if(statuses.length === 0) throw new BlogPostStatusesWereNotFoundException();
 
-        console.log(statuses);
         return statuses;
     }
 }

--- a/api/src/features/blog/controllers/blog-post.controller.ts
+++ b/api/src/features/blog/controllers/blog-post.controller.ts
@@ -5,10 +5,9 @@ import { Request } from 'express';
 import { JwtAuthGuard } from '@api/core/auth/jwt/jwt-auth.guard';
 
 import { BlogPost } from '../entities/blog-post.entity';
-import { BlogPostStatus } from '../entities/blog-post-status.entity';
 import { BlogPostService } from '../services/blog-post.service';
 import {
-    BlogPostCouldNotBeUpdated, BlogPostStatusesWereNotFoundException,
+    BlogPostCouldNotBeUpdated,
     BlogPostsWereNotFoundException,
     BlogPostWasNotFoundException
 } from '../exceptions/blog-post.exception';
@@ -21,7 +20,7 @@ export class BlogPostController {
 
     @Get('')
     @HttpCode(200)
-    async getPublishedPosts(
+    async getPosts(
         @Query('topic_id') topicId: string,
         @Query('published') published: string,
         @Req() request: Request
@@ -80,16 +79,5 @@ export class BlogPostController {
         if(!(await this.blogPostService.existsInTable(id))) throw new BlogPostWasNotFoundException();
 
         await this.blogPostService.deletePost(id);
-    }
-
-    @Get('statuses')
-    @HttpCode(200)
-    @UseGuards(JwtAuthGuard)
-    async getPostStatuses(@Req() request: Request): Promise<BlogPostStatus[]> {
-        const statuses = await this.blogPostService.getStatuses();
-        if(statuses.length === 0) throw new BlogPostStatusesWereNotFoundException();
-
-        console.log(statuses);
-        return statuses;
     }
 }

--- a/api/src/features/blog/entities/blog-post-status.entity.ts
+++ b/api/src/features/blog/entities/blog-post-status.entity.ts
@@ -1,4 +1,6 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
+
+import { BlogPost } from '../entities/blog-post.entity';
 
 @Entity('blog_post_status')
 export class BlogPostStatus {
@@ -11,4 +13,7 @@ export class BlogPostStatus {
 
     @Column({ type: 'varchar', length: 50, nullable: false, unique: true })
     public status: string;
+
+    @OneToMany(type => BlogPost, bp => bp.status)
+    public post: BlogPost;
 }

--- a/api/src/features/blog/entities/blog-post.entity.ts
+++ b/api/src/features/blog/entities/blog-post.entity.ts
@@ -25,7 +25,7 @@ export class BlogPost {
     @ManyToOne(type => BlogAuthor, ba => ba.id)
     public author: BlogAuthor;
 
-    @ManyToOne(type => BlogPostStatus, bps => bps.id)
+    @ManyToOne(type => BlogPostStatus, bps => bps.post)
     public status: BlogPostStatus;
 
     @ManyToMany(type => BlogTopic, bt => bt.posts, { onDelete: 'CASCADE' })

--- a/api/src/features/blog/exceptions/blog-post-status.exception.ts
+++ b/api/src/features/blog/exceptions/blog-post-status.exception.ts
@@ -1,0 +1,7 @@
+import { NotFoundException } from '@nestjs/common';
+
+export class BlogPostStatusesWereNotFoundException extends NotFoundException {
+    constructor() {
+        super('Unable to find blog post statuses.');
+    }
+}

--- a/api/src/features/blog/exceptions/blog-post.exception.ts
+++ b/api/src/features/blog/exceptions/blog-post.exception.ts
@@ -12,12 +12,6 @@ export class BlogPostsWereNotFoundException extends NotFoundException {
     }
 }
 
-export class BlogPostStatusesWereNotFoundException extends NotFoundException {
-    constructor() {
-        super('Unable to find blog post statuses.');
-    }
-}
-
 export class BlogPostCouldNotBeUpdated extends BadRequestException {
     constructor() {
         super('Blog post could not be updated.');

--- a/api/src/features/blog/services/blog-post-status.service.ts
+++ b/api/src/features/blog/services/blog-post-status.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { BlogPostStatus } from '../entities/blog-post-status.entity';
+
+@Injectable()
+export class BlogPostStatusService {
+    constructor(
+        @InjectRepository(BlogPostStatus)
+        private readonly blogPostStatusRepository: Repository<BlogPostStatus>
+    ) { }
+
+    public async getStatuses(): Promise<BlogPostStatus[]> {
+        return await this.blogPostStatusRepository
+            .createQueryBuilder('bps')
+            .getMany();
+    }
+}

--- a/api/src/features/blog/services/blog-post.service.ts
+++ b/api/src/features/blog/services/blog-post.service.ts
@@ -8,15 +8,12 @@ import { InternalServerErrorException } from '@api/core/http/http.exception';
 import { BlogPostAlreadyExistsException } from '../exceptions/blog-post.exception';
 
 import { BlogPost } from '../entities/blog-post.entity';
-import { BlogPostStatus } from '../entities/blog-post-status.entity';
 
 @Injectable()
 export class BlogPostService {
     constructor(
         @InjectRepository(BlogPost)
-        private readonly blogPostRepository: Repository<BlogPost>,
-        @InjectRepository(BlogPostStatus)
-        private readonly blogPostStatusRepository: Repository<BlogPostStatus>
+        private readonly blogPostRepository: Repository<BlogPost>
     ) { }
 
     public async existsInTable(id: number): Promise<boolean> {
@@ -99,12 +96,6 @@ export class BlogPostService {
             .innerJoinAndSelect('bp.topics', 'bt')
             .where('bt.id = :id', { id: topicId })
             .orderBy('bt.created_at', 'DESC')
-            .getMany();
-    }
-
-    public async getStatuses(): Promise<BlogPostStatus[]> {
-        return await this.blogPostStatusRepository
-            .createQueryBuilder('bps')
             .getMany();
     }
 

--- a/ui/src/app/modules/editor/components/post-editor/post-editor.component.ts
+++ b/ui/src/app/modules/editor/components/post-editor/post-editor.component.ts
@@ -87,17 +87,10 @@ export class PostEditorComponent implements OnDestroy, OnInit {
 
     private loadStatusData(): void {
         this.apiService.getPostStatuses().subscribe((res: BlogPostStatus[]) => {
-            console.log(res);
+            this.statusData = res;
         }, (error: HttpErrorResponse) => {
             this.notificationService.createNotification(error.error.message);
         })
-
-        // NOTE: This is not ideal, but the server is throwing weird nonsense when trying to query all topics (?)
-        this.statusData = [
-            new BlogPostStatus({ id: 1, status: 'DRAFT' }),
-            new BlogPostStatus({ id: 2, status: 'PUBLISHED' }),
-            new BlogPostStatus({ id: 3, status: 'ARCHIVED' })
-        ];
     }
 
     private loadTopicData(): void {

--- a/ui/src/app/modules/editor/components/post-editor/post-editor.component.ts
+++ b/ui/src/app/modules/editor/components/post-editor/post-editor.component.ts
@@ -86,11 +86,11 @@ export class PostEditorComponent implements OnDestroy, OnInit {
     }
 
     private loadStatusData(): void {
-        // this.apiService.getPostStatuses().subscribe((res: BlogPostStatus[]) => {
-        //     console.log(res);
-        // }, (error: HttpErrorResponse) => {
-        //     this.notificationService.createNotification(error.error.message);
-        // })
+        this.apiService.getPostStatuses().subscribe((res: BlogPostStatus[]) => {
+            console.log(res);
+        }, (error: HttpErrorResponse) => {
+            this.notificationService.createNotification(error.error.message);
+        })
 
         // NOTE: This is not ideal, but the server is throwing weird nonsense when trying to query all topics (?)
         this.statusData = [


### PR DESCRIPTION
## Summary

This was a weird error where NestJS does some funky stuff with controller routing. The solution ended up being to place my `BlogPostStatusController` before the `BlogPostController` in the `BlogModule` controller imports.

https://trello.com/c/QYb6elDx/62-09-01-2020-fix-query-error-for-post-statuses

## Notes

- Turns out that the order of importing controllers within a module matters 
- NestJS / TypeORM is reading the path parameters from the controller and for some reason it affects the query (if endpoint is changed then the error thrown reflects that)
