### PR TITLE
FIX: Published Date and Time for Posts

### DIFF
--- a/api/src/features/blog/services/blog-post.service.ts
+++ b/api/src/features/blog/services/blog-post.service.ts
@@ -61,7 +61,7 @@ export class BlogPostService {
             .leftJoinAndSelect('bp.author', 'ba')
             .leftJoinAndSelect('bp.status', 'bps')
             .innerJoinAndSelect('bp.topics', 'bt')
-            .orderBy('bp.created_at', 'DESC')
+            .orderBy('bp.updated_at', 'DESC')
             .getMany();
     }
 
@@ -72,7 +72,7 @@ export class BlogPostService {
             .leftJoinAndSelect('bp.status', 'bps')
             .innerJoinAndSelect('bp.topics', 'bt')
             .where('bps.status = :status', { status: status })
-            .orderBy('bp.created_at', 'DESC')
+            .orderBy('bp.updated_at', 'DESC')
             .getMany();
     }
 
@@ -84,7 +84,7 @@ export class BlogPostService {
             .innerJoinAndSelect('bp.topics', 'bt')
             .where('bps.status = :status', { status: status })
             .where('bt.id = :id', { id: topicId })
-            .orderBy('bp.created_at', 'DESC')
+            .orderBy('bp.updated_at', 'DESC')
             .getMany();
     }
 
@@ -95,7 +95,7 @@ export class BlogPostService {
             .leftJoinAndSelect('bp.status', 'bps')
             .innerJoinAndSelect('bp.topics', 'bt')
             .where('bt.id = :id', { id: topicId })
-            .orderBy('bt.created_at', 'DESC')
+            .orderBy('bt.updated_at', 'DESC')
             .getMany();
     }
 

--- a/ui/src/app/core/services/comparison.service.ts
+++ b/ui/src/app/core/services/comparison.service.ts
@@ -10,8 +10,8 @@ export class ComparisonService {
     constructor() { }
 
     posts = (p1: BlogPost, p2: BlogPost) => {
-        if(p1.created_at < p2.created_at) return 1;
-        if(p1.created_at > p2.created_at) return -1;
+        if(p1.updated_at < p2.updated_at) return 1;
+        if(p1.updated_at > p2.updated_at) return -1;
 
         return 0;
     };

--- a/ui/src/app/modules/blog/components/post-view/post-view.component.html
+++ b/ui/src/app/modules/blog/components/post-view/post-view.component.html
@@ -11,7 +11,7 @@
         </a>
     </div>
     
-    <p class='post__date' [innerHtml]='"Published: " + blogService.getFormattedDate(post.created_at)'></p>
+    <p class='post__date' [innerHtml]='"Updated: " + blogService.getFormattedDate(post.updated_at)'></p>
     
     <div class='post__topic-container'>
         <a class='post__topic-item' (click)='blogService.setActiveTopic(topic)' [routerLink]="['/blog']" *ngFor='let topic of post.topics'>

--- a/ui/src/app/modules/blog/components/post-view/post-view.component.scss
+++ b/ui/src/app/modules/blog/components/post-view/post-view.component.scss
@@ -27,6 +27,7 @@
 }
 
 .post__date {
+    font-style: italic;
     margin-bottom: $half-margin;
 }
 
@@ -37,7 +38,6 @@
 
 .post__topic-item {
     color: $color-primary;
-    font-style: italic;
     margin-top: $quarter-margin;
 }
 


### PR DESCRIPTION
# Summary

This PR just changes / fixes published date times for posts and putting a little more user experience into it (users will want to see when a post was last updated, but I was using 'created_at' for everything.

https://trello.com/c/na4qqjLf/67-09-05-2020-fix-published-date-and-time-for-posts
